### PR TITLE
Add missing getHandlerList methods

### DIFF
--- a/bukkit/src/main/java/net/william278/husktowns/events/ClaimEvent.java
+++ b/bukkit/src/main/java/net/william278/husktowns/events/ClaimEvent.java
@@ -29,6 +29,10 @@ public class ClaimEvent extends PlayerEvent implements Cancellable {
     public HandlerList getHandlers() {
         return HANDLER_LIST;
     }
+    
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
 
     @Override
     public boolean isCancelled() {

--- a/bukkit/src/main/java/net/william278/husktowns/events/TownCreateEvent.java
+++ b/bukkit/src/main/java/net/william278/husktowns/events/TownCreateEvent.java
@@ -28,6 +28,10 @@ public class TownCreateEvent extends PlayerEvent implements Cancellable {
     public HandlerList getHandlers() {
         return HANDLER_LIST;
     }
+    
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
 
     @Override
     public boolean isCancelled() {

--- a/bukkit/src/main/java/net/william278/husktowns/events/TownDisbandEvent.java
+++ b/bukkit/src/main/java/net/william278/husktowns/events/TownDisbandEvent.java
@@ -28,6 +28,10 @@ public class TownDisbandEvent extends PlayerEvent implements Cancellable {
     public HandlerList getHandlers() {
         return HANDLER_LIST;
     }
+    
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
 
     @Override
     public boolean isCancelled() {

--- a/bukkit/src/main/java/net/william278/husktowns/events/UnClaimEvent.java
+++ b/bukkit/src/main/java/net/william278/husktowns/events/UnClaimEvent.java
@@ -29,6 +29,10 @@ public class UnClaimEvent extends PlayerEvent implements Cancellable {
     public HandlerList getHandlers() {
         return HANDLER_LIST;
     }
+    
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
 
     @Override
     public boolean isCancelled() {


### PR DESCRIPTION
Simply adds the missing static getHandlerList to the events that are missing it, fixing an `IllegalPluginAccessException` when trying to subscribe to them.