### PR TITLE
Making rule names configurable

### DIFF
--- a/common/src/main/java/net/william278/husktowns/menu/RulesConfig.java
+++ b/common/src/main/java/net/william278/husktowns/menu/RulesConfig.java
@@ -10,7 +10,6 @@ import net.william278.husktowns.claim.Rules;
 import net.william278.husktowns.config.Locales;
 import net.william278.husktowns.town.Town;
 import net.william278.husktowns.user.CommandUser;
-import org.apache.commons.text.WordUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Locale;

--- a/common/src/main/java/net/william278/husktowns/menu/RulesConfig.java
+++ b/common/src/main/java/net/william278/husktowns/menu/RulesConfig.java
@@ -75,8 +75,10 @@ public class RulesConfig {
             }
         }
 
-        return line.append(plugin.getLocales().getLocale("town_rules_config_flag_name",
-                        WordUtils.capitalizeFully(entry.getKey().name().toLowerCase().replaceAll("_", " ")))
+        Locales locales = plugin.getLocales();
+        String flagName = entry.getKey().name().toLowerCase();
+        return line.append(locales.getLocale("town_rules_config_flag_name",
+                        locales.getRawLocale(("town_rule_name_"+flagName)).orElse(flagName))
                 .map(MineDown::toComponent).orElse(Component.empty()));
     }
 

--- a/common/src/main/java/net/william278/husktowns/menu/RulesConfig.java
+++ b/common/src/main/java/net/william278/husktowns/menu/RulesConfig.java
@@ -76,7 +76,7 @@ public class RulesConfig {
         }
 
         return line.append(plugin.getLocales().getLocale("town_rules_config_flag_name",
-                        WordUtils.capitalizeFully(entry.getKey().name().toLowerCase().replaceAll("_", "")))
+                        WordUtils.capitalizeFully(entry.getKey().name().toLowerCase().replaceAll("_", " ")))
                 .map(MineDown::toComponent).orElse(Component.empty()));
     }
 

--- a/common/src/main/java/net/william278/husktowns/menu/RulesConfig.java
+++ b/common/src/main/java/net/william278/husktowns/menu/RulesConfig.java
@@ -9,6 +9,7 @@ import net.william278.husktowns.claim.Flag;
 import net.william278.husktowns.claim.Rules;
 import net.william278.husktowns.town.Town;
 import net.william278.husktowns.user.CommandUser;
+import org.apache.commons.text.WordUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
@@ -73,8 +74,9 @@ public class RulesConfig {
                 line = line.append(Component.space());
             }
         }
+
         return line.append(plugin.getLocales().getLocale("town_rules_config_flag_name",
-                        entry.getKey().name().toLowerCase())
+                        WordUtils.capitalizeFully(entry.getKey().name().toLowerCase().replaceAll("_", "")))
                 .map(MineDown::toComponent).orElse(Component.empty()));
     }
 

--- a/common/src/main/resources/locales/en-gb.yml
+++ b/common/src/main/resources/locales/en-gb.yml
@@ -58,6 +58,15 @@ town_button_spawn_make_private: '[[☆ Set Private…]](#ff3300 show_text=&#ff33
 town_button_spawn_make_public: '[[⭐ Set Public…]](#00fb9a show_text=&#00fb9a&Make the spawn public run_command=/husktowns:town privacy public)'
 town_rules_config_title: '[✎ Town rule configuration for %1%:](#00fb9a) [(Claims/Farms/Plots…)](gray)'
 town_rules_config_flag_name: '[%1%](#ababab show_text=&#00fb9a&Name of the flag)'
+town_rule_name_monster_spawning: "Monster Spawning"
+town_rule_name_public_build_access: "Public Build Access"
+town_rule_name_public_interact_access: "Public Interact Access"
+town_rule_name_public_container_access: "Public Container Access"
+town_rule_name_fire_damage: "Fire Damage"
+town_rule_name_mob_griefing: "Mob Griefing"
+town_rule_name_public_farm_access: "Public Farm Access"
+town_rule_name_explosion_damage: "Explosion Damage"
+town_rule_name_pvp: "PvP"
 town_rules_config_flag_hover: '[Click to toggle the flag value for claims of type: %1%](#00fb9a)'
 town_rules_config_flag_true: '[☒](#00fb9a)'
 town_rules_config_flag_false: '[☐](#ff3300)'

--- a/common/src/main/resources/locales/es-es.yml
+++ b/common/src/main/resources/locales/es-es.yml
@@ -58,6 +58,15 @@ town_button_spawn_make_private: '[[☆ Cambia a Privado…]](#ff3300 show_text=&
 town_button_spawn_make_public: '[[⭐ Cambia a Publico…]](#00fb9a show_text=&#00fb9a&Hacer el spawn publico run_command=/husktowns:town privacy public)'
 town_rules_config_title: '[✎ Ajustes de la Ciudad para %1%:](#00fb9a) [(Terrenos/Granjas/Parcelas…)](gray)'
 town_rules_config_flag_name: '[%1%](#ababab show_text=&#00fb9a&Nombre de Ajuste)'
+town_rule_name_monster_spawning: "Monster Spawning"
+town_rule_name_public_build_access: "Public Build Access"
+town_rule_name_public_interact_access: "Public Interact Access"
+town_rule_name_public_container_access: "Public Container Access"
+town_rule_name_fire_damage: "Fire Damage"
+town_rule_name_mob_griefing: "Mob Griefing"
+town_rule_name_public_farm_access: "Public Farm Access"
+town_rule_name_explosion_damage: "Explosion Damage"
+town_rule_name_pvp: "PvP"
 town_rules_config_flag_hover: '[Click para cambiar el ajuste para todos los terrenos de tipo: %1%](#00fb9a)'
 town_rules_config_flag_true: '[☒](#00fb9a)'
 town_rules_config_flag_false: '[☐](#ff3300)'


### PR DESCRIPTION
I made the rule names that show up when you do `/town rules` configurable, not sure if this is something needed, but if it is here is my implementation not sure if its up to this repositories standards though.

