### PR TITLE
Add config to auto setspawn on first chunk claim of the town

### DIFF
--- a/common/src/main/java/net/william278/husktowns/config/Settings.java
+++ b/common/src/main/java/net/william278/husktowns/config/Settings.java
@@ -120,6 +120,9 @@ public class Settings {
     @YamlKey("general.claim_map_height")
     private int claimMapHeight = 9;
 
+    @YamlKey("general.first_claim_auto_setspawn")
+    private boolean firstClaimAutoSetSpawn = false;
+
     @YamlKey("general.brigadier_tab_completion")
     private boolean brigadierTabCompletion = true;
 
@@ -307,6 +310,10 @@ public class Settings {
 
     public int getClaimMapHeight() {
         return claimMapHeight;
+    }
+
+    public boolean doFirstClaimAutoSetSpawn() {
+        return firstClaimAutoSetSpawn;
     }
 
     public boolean doBrigadierTabCompletion() {

--- a/common/src/main/java/net/william278/husktowns/manager/ClaimsManager.java
+++ b/common/src/main/java/net/william278/husktowns/manager/ClaimsManager.java
@@ -89,6 +89,10 @@ public class ClaimsManager {
             plugin.getManager().editTown(user, claim.town(), (town -> {
                 town.setClaimCount(town.getClaimCount() + 1);
                 town.getLog().log(Action.of(user, Action.Type.CREATE_CLAIM, claim.claim().toString()));
+
+                if (town.getClaimCount() == 1 && plugin.getSettings().doFirstClaimAutoSetSpawn()) {
+                    plugin.getManager().towns().setTownSpawn(user, user.getPosition());
+                }
             }));
         }
         plugin.getDatabase().updateClaimWorld(claimWorld);


### PR DESCRIPTION
This PR adds the config to automatically set spawn on the first chunk claim (even if the owner unclaimed every chunk and reclaim one chunk). Sometimes players claim chunks but forget to set town spawn, so this can be useful if they teleport to another location.