### PR TITLE
PAPI: make placeholders built-in, add leaderboards, improve color

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ allprojects {
         mavenCentral()
         maven { url 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/' }
         maven { url 'https://repo.papermc.io/repository/maven-public/' }
+        maven { url 'https://repo.extendedclip.com/content/repositories/placeholderapi/' }
         maven { url 'https://repo.minebench.de/' }
         maven { url 'https://jitpack.io' }
         maven { url 'https://repo.mikeprimm.com/' }

--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     compileOnly 'net.william278:HuskHomes2:4.0.2'
     compileOnly 'com.github.MilkBowl:VaultAPI:1.7.1'
     compileOnly 'com.github.Emibergo02:RedisEconomy:4.0-SNAPSHOT'
+    compileOnly 'me.clip:placeholderapi:2.11.3'
     compileOnly 'net.luckperms:api:5.4'
 
     testImplementation 'com.github.seeseemelk:MockBukkit-v1.16:1.5.2'

--- a/bukkit/src/main/java/net/william278/husktowns/BukkitHuskTowns.java
+++ b/bukkit/src/main/java/net/william278/husktowns/BukkitHuskTowns.java
@@ -137,6 +137,9 @@ public final class BukkitHuskTowns extends JavaPlugin implements HuskTowns, Plug
         if (settings.doLuckPermsHook() && plugins.getPlugin("LuckPerms") != null) {
             this.registerHook(new LuckPermsHook(this));
         }
+        if (settings.doPlaceholderAPIHook() && plugins.getPlugin("PlaceholderAPI") != null) {
+            this.registerHook(new PlaceholderAPIHook(this));
+        }
         if (settings.doHuskHomesHook() && plugins.getPlugin("HuskHomes") != null) {
             this.registerHook(new HuskHomesHook(this));
         }

--- a/bukkit/src/main/java/net/william278/husktowns/hook/PlaceholderAPIHook.java
+++ b/bukkit/src/main/java/net/william278/husktowns/hook/PlaceholderAPIHook.java
@@ -198,7 +198,7 @@ public class PlaceholderAPIHook extends Hook {
                         .orElse(plugin.getLocales().getRawLocale("placeholder_not_claimed")
                                 .orElse("Not claimed"));
 
-                case "current_town_location_color" -> plugin.getClaimAt(player.getPosition())
+                case "current_location_town_color" -> plugin.getClaimAt(player.getPosition())
                         .map(TownClaim::town)
                         .map(Town::getColorRgb)
                         .orElse(WILDERNESS_COLOR);

--- a/bukkit/src/main/java/net/william278/husktowns/hook/PlaceholderAPIHook.java
+++ b/bukkit/src/main/java/net/william278/husktowns/hook/PlaceholderAPIHook.java
@@ -1,0 +1,278 @@
+package net.william278.husktowns.hook;
+
+import me.clip.placeholderapi.PlaceholderAPIPlugin;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import net.william278.husktowns.HuskTowns;
+import net.william278.husktowns.audit.Action;
+import net.william278.husktowns.claim.Claim;
+import net.william278.husktowns.claim.TownClaim;
+import net.william278.husktowns.listener.Operation;
+import net.william278.husktowns.town.Member;
+import net.william278.husktowns.town.Role;
+import net.william278.husktowns.town.Town;
+import net.william278.husktowns.user.BukkitUser;
+import net.william278.husktowns.user.OnlineUser;
+import net.william278.husktowns.user.User;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class PlaceholderAPIHook extends Hook {
+    public PlaceholderAPIHook(@NotNull HuskTowns plugin) {
+        super(plugin, "PlaceholderAPI");
+    }
+
+    @Override
+    protected void onEnable() {
+        new HuskTownsExpansion(plugin).register();
+    }
+
+    public static class HuskTownsExpansion extends PlaceholderExpansion {
+
+        @NotNull
+        private final HuskTowns plugin;
+
+        private HuskTownsExpansion(@NotNull HuskTowns plugin) {
+            this.plugin = plugin;
+        }
+
+        @Override
+        public String onRequest(@Nullable OfflinePlayer offlinePlayer, @NotNull String params) {
+            if (!plugin.isLoaded()) {
+                return plugin.getLocales().getRawLocale("not_applicable").orElse("N/A");
+            }
+
+            // Ensure the player is online
+            if (offlinePlayer == null || !offlinePlayer.isOnline() || offlinePlayer.getPlayer() == null) {
+                return plugin.getLocales().getRawLocale("placeholder_player_offline")
+                        .orElse("Player offline");
+            }
+
+            // Return the requested placeholder
+            final OnlineUser player = BukkitUser.adapt(offlinePlayer.getPlayer());
+            return switch (params) {
+                case "town_name" -> plugin.getUserTown(player)
+                        .map(Member::town)
+                        .map(Town::getName)
+                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
+                                .orElse("Not in town"));
+
+                case "town_role" -> plugin.getUserTown(player)
+                        .map(Member::role)
+                        .map(Role::getName)
+                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
+                                .orElse("Not in town"));
+
+                case "town_mayor" -> plugin.getUserTown(player)
+                        .map(Member::town)
+                        .map(town -> resolveTownMemberName(town, town.getMayor()).orElse("?"))
+                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
+                                .orElse("Not in town"));
+
+                case "town_color" -> plugin.getUserTown(player)
+                        .map(Member::town)
+                        .map(Town::getColorRgb)
+                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
+                                .orElse("Not in town"));
+
+                case "town_members" -> plugin.getUserTown(player)
+                        .map(Member::town)
+                        .map(town -> town.getMembers().keySet().stream()
+                                .map(uuid -> resolveTownMemberName(town, uuid).orElse("?"))
+                                .collect(Collectors.joining(", ")))
+                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
+                                .orElse("Not in town"));
+
+                case "town_member_count" -> plugin.getUserTown(player)
+                        .map(Member::town)
+                        .map(Town::getMembers)
+                        .map(members -> String.valueOf(members.size()))
+                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
+                                .orElse("Not in town"));
+
+                case "town_claim_count" -> plugin.getUserTown(player)
+                        .map(Member::town)
+                        .map(Town::getClaimCount)
+                        .map(String::valueOf)
+                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
+                                .orElse("Not in town"));
+
+                case "town_max_claims" -> plugin.getUserTown(player)
+                        .map(Member::town)
+                        .map(town -> town.getMaxClaims(plugin))
+                        .map(String::valueOf)
+                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
+                                .orElse("Not in town"));
+
+                case "town_max_members" -> plugin.getUserTown(player)
+                        .map(Member::town)
+                        .map(town -> town.getMaxMembers(plugin))
+                        .map(String::valueOf)
+                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
+                                .orElse("Not in town"));
+
+                case "town_money" -> plugin.getUserTown(player)
+                        .map(Member::town)
+                        .map(Town::getMoney)
+                        .map(String::valueOf)
+                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
+                                .orElse("Not in town"));
+
+                case "town_level_up_cost" -> plugin.getUserTown(player)
+                        .map(Member::town)
+                        .map(town -> plugin.getLevels().getLevelUpCost(town.getLevel()))
+                        .map(String::valueOf)
+                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
+                                .orElse("Not in town"));
+
+                case "town_level" -> plugin.getUserTown(player)
+                        .map(Member::town)
+                        .map(Town::getLevel)
+                        .map(String::valueOf)
+                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
+                                .orElse("Not in town"));
+
+                case "town_max_level" -> plugin.getUserTown(player)
+                        .map(Member::town)
+                        .map(town -> plugin.getLevels().getMaxLevel())
+                        .map(String::valueOf)
+                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
+                                .orElse("Not in town"));
+
+                case "current_location_town" -> plugin.getClaimAt(player.getPosition())
+                        .map(TownClaim::town)
+                        .map(Town::getName)
+                        .orElse(plugin.getLocales().getRawLocale("placeholder_wilderness")
+                                .orElse("Wilderness"));
+
+                case "current_location_can_build" -> getBooleanValue(!plugin.getOperationHandler()
+                        .cancelOperation(Operation.of(player, Operation.Type.BLOCK_PLACE, player.getPosition())));
+
+                case "current_location_can_interact" -> getBooleanValue(!plugin.getOperationHandler()
+                        .cancelOperation(Operation.of(player, Operation.Type.BLOCK_INTERACT, player.getPosition())));
+
+                case "current_location_can_open_containers" -> getBooleanValue(!plugin.getOperationHandler()
+                        .cancelOperation(Operation.of(player, Operation.Type.CONTAINER_OPEN, player.getPosition())));
+
+                case "current_location_claim_type" -> plugin.getClaimAt(player.getPosition())
+                        .map(TownClaim::claim)
+                        .map(Claim::getType)
+                        .map(Claim.Type::name)
+                        .map(String::toLowerCase)
+                        .orElse(plugin.getLocales().getRawLocale("placeholder_wilderness")
+                                .orElse("Wilderness"));
+
+                case "current_location_plot_members" -> plugin.getClaimAt(player.getPosition())
+                        .map(townClaim -> {
+                            final Claim claim = townClaim.claim();
+                            if (claim.getType() == Claim.Type.PLOT) {
+                                return plugin.getLocales().getRawLocale("placeholder_not_a_plot")
+                                        .orElse("Not a plot");
+                            }
+
+                            return claim.getPlotMembers().stream()
+                                    .map(user -> resolveTownMemberName(townClaim.town(), user).orElse("?"))
+                                    .collect(Collectors.joining(", "));
+                        })
+                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_claimed")
+                                .orElse("Not claimed"));
+
+                case "current_location_plot_managers" -> plugin.getClaimAt(player.getPosition())
+                        .map(townClaim -> {
+                            final Claim claim = townClaim.claim();
+                            if (claim.getType() == Claim.Type.PLOT) {
+                                return plugin.getLocales().getRawLocale("placeholder_not_a_plot")
+                                        .orElse("Not a plot");
+                            }
+
+                            return claim.getPlotMembers().stream()
+                                    .filter(claim::isPlotManager)
+                                    .map(user -> resolveTownMemberName(townClaim.town(), user).orElse("?"))
+                                    .collect(Collectors.joining(", "));
+                        })
+                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_claimed")
+                                .orElse("Not claimed"));
+
+                case "current_location_town_money" -> plugin.getClaimAt(player.getPosition())
+                        .map(TownClaim::town)
+                        .map(Town::getMoney)
+                        .map(String::valueOf)
+                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_claimed")
+                                .orElse("Not claimed"));
+
+                case "current_location_town_level" -> plugin.getClaimAt(player.getPosition())
+                        .map(TownClaim::town)
+                        .map(Town::getLevel)
+                        .map(String::valueOf)
+                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_claimed")
+                                .orElse("Not claimed"));
+
+                case "current_location_town_level_up_cost" -> plugin.getClaimAt(player.getPosition())
+                        .map(TownClaim::town)
+                        .map(town -> plugin.getLevels().getLevelUpCost(town.getLevel()))
+                        .map(String::valueOf)
+                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
+                                .orElse("Not in town"));
+
+                case "current_location_town_max_claims" -> plugin.getClaimAt(player.getPosition())
+                        .map(TownClaim::town)
+                        .map(town -> town.getMaxClaims(plugin))
+                        .map(String::valueOf)
+                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_claimed")
+                                .orElse("Not claimed"));
+
+                case "current_location_town_max_members" -> plugin.getClaimAt(player.getPosition())
+                        .map(TownClaim::town)
+                        .map(town -> town.getMaxMembers(plugin))
+                        .map(String::valueOf)
+                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_claimed")
+                                .orElse("Not claimed"));
+
+                default -> null;
+            };
+        }
+
+        // Resolve a cached town member name from a UUID
+        private Optional<String> resolveTownMemberName(@NotNull Town town, @NotNull UUID uuid) {
+            return town.getLog().getActions().values().stream()
+                    .map(Action::getUser).filter(Optional::isPresent).map(Optional::get)
+                    .filter(user -> user.getUuid().equals(uuid))
+                    .map(User::getUsername)
+                    .findFirst();
+        }
+
+        @Override
+        public boolean persist() {
+            return true;
+        }
+
+        @Override
+        @NotNull
+        public String getIdentifier() {
+            return "husktowns";
+        }
+
+        @Override
+        @NotNull
+        public String getAuthor() {
+            return "William278";
+        }
+
+        @Override
+        @NotNull
+        public String getVersion() {
+            return plugin.getVersion().toStringWithoutMetadata();
+        }
+
+        @NotNull
+        private String getBooleanValue(final boolean bool) {
+            return bool ? PlaceholderAPIPlugin.booleanTrue() : PlaceholderAPIPlugin.booleanFalse();
+        }
+
+    }
+
+}

--- a/bukkit/src/main/java/net/william278/husktowns/hook/PlaceholderAPIHook.java
+++ b/bukkit/src/main/java/net/william278/husktowns/hook/PlaceholderAPIHook.java
@@ -33,6 +33,9 @@ public class PlaceholderAPIHook extends Hook {
 
     public static class HuskTownsExpansion extends PlaceholderExpansion {
 
+        private static final String NOT_IN_TOWN_COLOR = "#aaaaaa";
+        private static final String WILDERNESS_COLOR = "#2e2e2e";
+
         @NotNull
         private final HuskTowns plugin;
 
@@ -76,8 +79,7 @@ public class PlaceholderAPIHook extends Hook {
                 case "town_color" -> plugin.getUserTown(player)
                         .map(Member::town)
                         .map(Town::getColorRgb)
-                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
-                                .orElse("Not in town"));
+                        .orElse(NOT_IN_TOWN_COLOR);
 
                 case "town_members" -> plugin.getUserTown(player)
                         .map(Member::town)
@@ -196,6 +198,11 @@ public class PlaceholderAPIHook extends Hook {
                         })
                         .orElse(plugin.getLocales().getRawLocale("placeholder_not_claimed")
                                 .orElse("Not claimed"));
+
+                case "current_town_location_color" -> plugin.getClaimAt(player.getPosition())
+                        .map(TownClaim::town)
+                        .map(Town::getColorRgb)
+                        .orElse(WILDERNESS_COLOR);
 
                 case "current_location_town_money" -> plugin.getClaimAt(player.getPosition())
                         .map(TownClaim::town)

--- a/common/src/main/java/net/william278/husktowns/config/Settings.java
+++ b/common/src/main/java/net/william278/husktowns/config/Settings.java
@@ -152,6 +152,10 @@ public class Settings {
     @YamlKey("general.luckperms_contexts_hook")
     private boolean luckPermsHook = true;
 
+    @YamlComment("Use PlaceholderAPI for placeholders")
+    @YamlKey("general.placeholderapi_hook")
+    private boolean placeholderAPIHook = true;
+
     @YamlComment("Use HuskHomes for improved teleportation")
     @YamlKey("general.huskhomes_hook")
     private boolean huskHomesHook = true;
@@ -342,6 +346,10 @@ public class Settings {
 
     public boolean doLuckPermsHook() {
         return luckPermsHook;
+    }
+
+    public boolean doPlaceholderAPIHook() {
+        return placeholderAPIHook;
     }
 
     public boolean doHuskHomesHook() {

--- a/common/src/main/java/net/william278/husktowns/town/Town.java
+++ b/common/src/main/java/net/william278/husktowns/town/Town.java
@@ -454,7 +454,7 @@ public class Town {
     }
 
     /**
-     * Get the {@link Color} of the town as a hex string
+     * Get the {@link Color} of the town as a hex string, including the leading {@code #}
      *
      * @return the {@link Color} of the town as a hex string (e.g. {@code #FF0000})
      */

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ javaVersion=16
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 org.gradle.daemon=true
 
-plugin_version=2.1.1
+plugin_version=2.1.2
 plugin_archive=husktowns
 
 sqlite_driver_version=3.39.4.1


### PR DESCRIPTION
Fixes #207 and closes #202

This PR builds the PlaceholderAPI hook into the plugin, and adds a few placeholders/ensures the town color placeholder will return gray if the user is not in a town.

Placeholders that return a town name based on the top towns:
* Adds `%husktowns_town_leaderboard_members_{index}%` placeholder
* Adds `%husktowns_town_leaderboard_claims_{index}%` placeholder
* Adds `%husktowns_town_leaderboard_money_{index}%` placeholder
* Adds `%husktowns_town_leaderboard_claims_{index}%` placeholder

Also, a new placeholder for the color of the town you're standing in
* Adds `%husktowns_current_location_town_color%` placeholder (returns wilderness color if not in a town claim)