### PR TITLE
Add option to require minimum town creation collateral cost

### DIFF
--- a/bukkit/src/main/java/net/william278/husktowns/hook/RedisEconomyHook.java
+++ b/bukkit/src/main/java/net/william278/husktowns/hook/RedisEconomyHook.java
@@ -37,6 +37,11 @@ public class RedisEconomyHook extends EconomyHook {
     }
 
     @Override
+    public boolean hasMoney(@NotNull OnlineUser user, @NotNull BigDecimal amount) {
+        return redisEconomy.getDefaultCurrency().has(user.getUuid(), amount.doubleValue());
+    }
+
+    @Override
     public boolean takeMoney(@NotNull OnlineUser user, @NotNull BigDecimal amount, @Nullable String reason) {
         return redisEconomy.getDefaultCurrency().withdrawPlayer(user.getUuid(), user.getUsername(), amount.doubleValue(), reason).transactionSuccess();
     }
@@ -47,7 +52,7 @@ public class RedisEconomyHook extends EconomyHook {
     }
 
     @Override
-    public String formatMoney(@NotNull BigDecimal amount) {
+    public @NotNull String formatMoney(@NotNull BigDecimal amount) {
         return redisEconomy.getDefaultCurrency().format(amount.doubleValue());
     }
 

--- a/bukkit/src/main/java/net/william278/husktowns/hook/RedisEconomyHook.java
+++ b/bukkit/src/main/java/net/william278/husktowns/hook/RedisEconomyHook.java
@@ -52,7 +52,8 @@ public class RedisEconomyHook extends EconomyHook {
     }
 
     @Override
-    public @NotNull String formatMoney(@NotNull BigDecimal amount) {
+    @NotNull
+    public String formatMoney(@NotNull BigDecimal amount) {
         return redisEconomy.getDefaultCurrency().format(amount.doubleValue());
     }
 

--- a/bukkit/src/main/java/net/william278/husktowns/hook/VaultEconomyHook.java
+++ b/bukkit/src/main/java/net/william278/husktowns/hook/VaultEconomyHook.java
@@ -45,6 +45,11 @@ public class VaultEconomyHook extends EconomyHook {
     }
 
     @Override
+    public boolean hasMoney(@NotNull OnlineUser user, @NotNull BigDecimal amount) {
+        return economy.has(((BukkitUser) user).getPlayer(), amount.doubleValue());
+    }
+
+    @Override
     public boolean takeMoney(@NotNull OnlineUser user, @NotNull BigDecimal amount, @Nullable String reason) {
         return economy.withdrawPlayer(((BukkitUser) user).getPlayer(), amount.doubleValue()).transactionSuccess();
     }
@@ -55,7 +60,7 @@ public class VaultEconomyHook extends EconomyHook {
     }
 
     @Override
-    public String formatMoney(@NotNull BigDecimal amount) {
+    public @NotNull String formatMoney(@NotNull BigDecimal amount) {
         return economy.format(amount.doubleValue());
     }
 

--- a/bukkit/src/main/java/net/william278/husktowns/hook/VaultEconomyHook.java
+++ b/bukkit/src/main/java/net/william278/husktowns/hook/VaultEconomyHook.java
@@ -60,7 +60,8 @@ public class VaultEconomyHook extends EconomyHook {
     }
 
     @Override
-    public @NotNull String formatMoney(@NotNull BigDecimal amount) {
+    @NotNull
+    public String formatMoney(@NotNull BigDecimal amount) {
         return economy.format(amount.doubleValue());
     }
 

--- a/common/src/main/java/net/william278/husktowns/config/Settings.java
+++ b/common/src/main/java/net/william278/husktowns/config/Settings.java
@@ -201,6 +201,10 @@ public class Settings {
     @YamlKey("towns.allow_unicode_bios")
     private boolean allowUnicodeMeta = true;
 
+    @YamlComment("Require the level 1 cost as collateral when creating a town (this cost is otherwise ignored)")
+    @YamlKey("towns.require_first_level_collateral")
+    private boolean requireFirstLevelCollateral = false;
+
     @YamlComment("The minimum distance apart towns must be, in chunks")
     @YamlKey("towns.minimum_chunk_separation")
     private int minimumChunkSeparation = 0;
@@ -405,6 +409,10 @@ public class Settings {
 
     public boolean doAllowUnicodeMeta() {
         return allowUnicodeMeta;
+    }
+
+    public boolean doRequireFirstLevelCollateral() {
+        return requireFirstLevelCollateral;
     }
 
     public int getMinimumChunkSeparation() {

--- a/common/src/main/java/net/william278/husktowns/hook/EconomyHook.java
+++ b/common/src/main/java/net/william278/husktowns/hook/EconomyHook.java
@@ -27,16 +27,41 @@ public abstract class EconomyHook extends Hook {
     }
 
     /**
+     * Check if a player has enough money
+     *
+     * @param user   The player to check
+     * @param amount The amount of money to check
+     * @return Whether the player has enough money
+     */
+    public abstract boolean hasMoney(@NotNull OnlineUser user, @NotNull BigDecimal amount);
+
+    /**
      * Take money from a player
-     * @param user The player to take money from
+     *
+     * @param user   The player to take money from
      * @param amount The amount of money to take
      * @param reason The reason for taking money
      * @return Whether the transaction was successful, false if the player does not have enough money
      */
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public abstract boolean takeMoney(@NotNull OnlineUser user, @NotNull BigDecimal amount, @Nullable String reason);
 
+    /**
+     * Give money to a player
+     *
+     * @param user   The player to give money to
+     * @param amount The amount of money to give
+     * @param reason The reason for giving money
+     */
     public abstract void giveMoney(@NotNull OnlineUser user, @NotNull BigDecimal amount, @Nullable String reason);
 
+    /**
+     * Format a money amount
+     *
+     * @param amount The amount to format
+     * @return The formatted amount
+     */
+    @NotNull
     public abstract String formatMoney(@NotNull BigDecimal amount);
 
 }


### PR DESCRIPTION
Close #211

Adds an option to use the first level cost that currently goes unused as the required collateral to create a town. This is off by default. Useful for if you want to prevent players from immediately creating a town.