### PR TITLE
Re-add /town player command

### DIFF
--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     compileOnly 'de.themoep:minedown-adventure:1.7.2-SNAPSHOT'
     compileOnly 'commons-io:commons-io:2.13.0'
     compileOnly 'net.william278:annotaml:2.0.2'
-    compileOnly 'net.william278:huskhomes:4.3.2'
+    compileOnly 'net.william278:huskhomes:4.4'
     compileOnly 'net.william278:DesertWell:2.0.4'
     compileOnly 'com.github.MilkBowl:VaultAPI:1.7.1'
     compileOnly 'com.github.Emibergo02:RedisEconomy:3.2-SNAPSHOT'

--- a/bukkit/src/main/resources/commodore/town.commodore
+++ b/bukkit/src/main/resources/commodore/town.commodore
@@ -110,6 +110,9 @@ town {
     chat {
         message brigadier:string greedy_phrase;
     }
+    player {
+        player brigadier:string single_word;
+    }
     deeds {
         town brigadier:string single_word;
     }

--- a/common/src/main/java/net/william278/husktowns/command/TownCommand.java
+++ b/common/src/main/java/net/william278/husktowns/command/TownCommand.java
@@ -71,6 +71,7 @@ public final class TownCommand extends Command {
                 new ClearSpawnCommand(this, plugin),
                 new PrivacyCommand(this, plugin),
                 new ChatCommand(this, plugin),
+                new PlayerCommand(this, plugin),
                 new OverviewCommand(this, plugin, OverviewCommand.Type.DEEDS),
                 new OverviewCommand(this, plugin, OverviewCommand.Type.CENSUS),
                 new LogCommand(this, plugin),
@@ -937,6 +938,25 @@ public final class TownCommand extends Command {
             final Optional<String> message = parseGreedyString(args, 0);
             plugin.getManager().towns().sendChatMessage(user, message.orElse(null));
         }
+    }
+
+    private static class PlayerCommand extends ChildCommand {
+        protected PlayerCommand(@NotNull Command parent, @NotNull HuskTowns plugin) {
+            super("player", List.of("who"), parent, "<player>", plugin);
+            this.setConsoleExecutable(true);
+        }
+
+        @Override
+        public void execute(@NotNull CommandUser executor, @NotNull String[] args) {
+            final Optional<String> target = parseStringArg(args, 0);
+            if (target.isEmpty()) {
+                plugin.getLocales().getLocale("error_invalid_syntax", getUsage())
+                        .ifPresent(executor::sendMessage);
+                return;
+            }
+            plugin.getManager().towns().showPlayerInfo(executor, target.get());
+        }
+
     }
 
     private static class DisbandCommand extends ChildCommand implements TabProvider {

--- a/common/src/main/java/net/william278/husktowns/manager/TownsManager.java
+++ b/common/src/main/java/net/william278/husktowns/manager/TownsManager.java
@@ -29,10 +29,7 @@ import net.william278.husktowns.menu.RulesConfig;
 import net.william278.husktowns.network.Message;
 import net.william278.husktowns.network.Payload;
 import net.william278.husktowns.town.*;
-import net.william278.husktowns.user.OnlineUser;
-import net.william278.husktowns.user.Preferences;
-import net.william278.husktowns.user.SavedUser;
-import net.william278.husktowns.user.User;
+import net.william278.husktowns.user.*;
 import net.william278.husktowns.util.Validator;
 import net.william278.paginedown.PaginatedList;
 import org.jetbrains.annotations.NotNull;
@@ -202,7 +199,7 @@ public class TownsManager {
         final Optional<Town> town = plugin.findTown(invite.getTownId());
         if (plugin.getUserTown(user).isPresent() || town.isEmpty()) {
             plugin.log(Level.WARNING, "Received an invalid invite from "
-                                      + invite.getSender().getUsername() + " to " + invite.getTownId());
+                    + invite.getSender().getUsername() + " to " + invite.getTownId());
             return;
         }
 
@@ -851,6 +848,37 @@ public class TownsManager {
                 (member -> RulesConfig.of(plugin, member.town(), user).show()));
     }
 
+    public void showPlayerInfo(@NotNull CommandUser executor, @NotNull String username) {
+        final Optional<SavedUser> user = plugin.getDatabase().getUser(username);
+        if (user.isEmpty()) {
+            plugin.getLocales().getLocale("error_user_not_found", username)
+                    .ifPresent(executor::sendMessage);
+            return;
+        }
+
+        final Optional<Member> optionalMember = plugin.getUserTown(user.get().user());
+        username = user.get().user().getUsername();
+        if (optionalMember.isEmpty()) {
+            plugin.getLocales().getLocale("town_player_info_not_in_town", username)
+                    .ifPresent(executor::sendMessage);
+            return;
+        }
+
+        final Member member = optionalMember.get();
+        plugin.getLocales().getLocale("town_player_info",
+                        username, member.town().getName(), member.role().getName(), member.town().getColorRgb(),
+                        Integer.toString(member.town().getLevel()),
+                        plugin.getEconomyHook().map(hook -> hook.formatMoney(member.town().getMoney()))
+                                .orElse(plugin.getLocales().getRawLocale("not_applicable").orElse("N/A")),
+                        Integer.toString(member.town().getClaimCount()), Integer.toString(member.town().getMaxClaims(plugin)),
+                        Integer.toString(member.town().getMembers().size()), Integer.toString(member.town().getMaxMembers(plugin)),
+                        member.town().getBio()
+                                .map(bio -> plugin.getLocales().wrapText(bio, 40))
+                                .map(bio -> plugin.getLocales().truncateText(bio, 120))
+                                .orElse(plugin.getLocales().getRawLocale("not_applicable").orElse("N/A")))
+                .ifPresent(executor::sendMessage);
+    }
+
     public void sendChatMessage(@NotNull OnlineUser user, @Nullable String message) {
         plugin.getManager().ifMember(user, Privilege.CHAT, (member -> {
             if (message == null) {
@@ -866,7 +894,7 @@ public class TownsManager {
             // Send locally
             sendLocalChatMessage(message, member, plugin);
 
-            // Send globally via message
+            // Send globally via a message
             plugin.getMessageBroker().ifPresent(broker -> Message.builder()
                     .type(Message.Type.TOWN_CHAT_MESSAGE)
                     .payload(Payload.string(message))
@@ -885,4 +913,5 @@ public class TownsManager {
                 .ifPresent(locale -> plugin.getManager().sendTownMessage(town, locale));
         plugin.getManager().admin().sendLocalSpyMessage(town, member, text);
     }
+
 }

--- a/common/src/main/resources/locales/en-gb.yml
+++ b/common/src/main/resources/locales/en-gb.yml
@@ -141,7 +141,7 @@ town_chat_talking: '[You are now talking in the town chat.](#00fb9a) [[☄ Toggl
 town_chat_not_talking: '[You are no longer talking in the town chat.](#00fb9a) [[☄ Toggle…]](#c8ff00 show_text=&#c8ff00&Click to toggle town chat suggest_command=/husktowns:town chat)'
 town_chat_message_format: '[[%1%]](%2% show_text=&%2%&Town chat message) [%3%:](gray show_text=&7%4%) %5%'
 town_chat_spy_message_format: '[[%1%/Spy]](gray show_text=&7Town chat message) [%2%:](gray show_text=&7%3%) [%4%](dark_gray)'
-town_player_info: '[%1% is currently a member of](#00fb9a) [%2%](#00fb9a bold show_text=&#00fb9a&%2%\n&#55ff2b&⚓ Level: %5%\n&#ffc62b&⛨ Coffers: %6%\n&%4%&█ Claims: %7%/%8%\n&#b0ff55&☻ Population: %9%/%10%\n\n&7✎ Bio: %11% run_command=/husktowns:town info %2%) [and is a %3%.](#00fb9a) [[⚓ More info…]](%4% show_text=&%4%&Click to view an overview of %2% run_command=/husktowns:town info %2%)'
+town_player_info: '[%1% is currently a %3% of](#00fb9a) [%2%](#00fb9a bold show_text=&#00fb9a&%2%\n&#55ff2b&⚓ Level: %5%\n&#ffc62b&⛨ Coffers: %6%\n&%4%&█ Claims: %7%/%8%\n&#b0ff55&☻ Population: %9%/%10%\n\n&7✎ Bio: %11% run_command=/husktowns:town info %2%) [[⚓ More info…]](%4% show_text=&%4%&Click to view an overview of %2% run_command=/husktowns:town info %2%)'
 town_player_info_not_in_town: '[%1% is not currently a member of any town.](#00fb9a)'
 town_bonus_set: '[❤ Set the bonus](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&The type of bonus) [of the town %2% to %3%.](#00fb9a)'
 town_bonus_cleared: '[❤ The bonus](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&The type of bonus) [of %2% has been cleared.](#00fb9a)'

--- a/common/src/main/resources/locales/en-gb.yml
+++ b/common/src/main/resources/locales/en-gb.yml
@@ -141,7 +141,7 @@ town_chat_talking: '[You are now talking in the town chat.](#00fb9a) [[☄ Toggl
 town_chat_not_talking: '[You are no longer talking in the town chat.](#00fb9a) [[☄ Toggle…]](#c8ff00 show_text=&#c8ff00&Click to toggle town chat suggest_command=/husktowns:town chat)'
 town_chat_message_format: '[[%1%]](%2% show_text=&%2%&Town chat message) [%3%:](gray show_text=&7%4%) %5%'
 town_chat_spy_message_format: '[[%1%/Spy]](gray show_text=&7Town chat message) [%2%:](gray show_text=&7%3%) [%4%](dark_gray)'
-town_player_info: '[%1% is currently a member of](#00fb9a) [%2%](#00fb9a bold show_text=&#00fb9a&%2%\n&#55ff2b&⚓ Level: %5%\n&#ffc62b&⛨ Coffers: %6%\n&%4%&█ Claims: %7%/%8%\n&#b0ff55&☻ Population: %9%/%10%\n\n&7%11% run_command=/husktowns:town info %2%) [and is a %3%.](#00fb9a) [[⚓ More info…]](%4% show_text=&%4%&Click to view an overview of %2% run_command=/husktowns:town info %2%)'
+town_player_info: '[%1% is currently a member of](#00fb9a) [%2%](#00fb9a bold show_text=&#00fb9a&%2%\n&#55ff2b&⚓ Level: %5%\n&#ffc62b&⛨ Coffers: %6%\n&%4%&█ Claims: %7%/%8%\n&#b0ff55&☻ Population: %9%/%10%\n\n&7✎ Bio: %11% run_command=/husktowns:town info %2%) [and is a %3%.](#00fb9a) [[⚓ More info…]](%4% show_text=&%4%&Click to view an overview of %2% run_command=/husktowns:town info %2%)'
 town_player_info_not_in_town: '[%1% is not currently a member of any town.](#00fb9a)'
 town_bonus_set: '[❤ Set the bonus](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&The type of bonus) [of the town %2% to %3%.](#00fb9a)'
 town_bonus_cleared: '[❤ The bonus](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&The type of bonus) [of %2% has been cleared.](#00fb9a)'

--- a/common/src/main/resources/locales/en-gb.yml
+++ b/common/src/main/resources/locales/en-gb.yml
@@ -141,6 +141,8 @@ town_chat_talking: '[You are now talking in the town chat.](#00fb9a) [[☄ Toggl
 town_chat_not_talking: '[You are no longer talking in the town chat.](#00fb9a) [[☄ Toggle…]](#c8ff00 show_text=&#c8ff00&Click to toggle town chat suggest_command=/husktowns:town chat)'
 town_chat_message_format: '[[%1%]](%2% show_text=&%2%&Town chat message) [%3%:](gray show_text=&7%4%) %5%'
 town_chat_spy_message_format: '[[%1%/Spy]](gray show_text=&7Town chat message) [%2%:](gray show_text=&7%3%) [%4%](dark_gray)'
+town_player_info: '[%1% is currently a member of](#00fb9a) [%2%](#00fb9a bold show_text=&#00fb9a&%2%\n&#55ff2b&⚓ Level: %5%\n&#ffc62b&⛨ Coffers: %6%\n&%4%&█ Claims: %7%/%8%\n&#b0ff55&☻ Population: %9%/%10%\n\n&7%11% run_command=/husktowns:town info %2%) [and is a %3%.](#00fb9a) [[⚓ More info…]](%4% show_text=&%4%&Click to view an overview of %2% run_command=/husktowns:town info %2%)'
+town_player_info_not_in_town: '[%1% is not currently a member of any town.](#00fb9a)'
 town_bonus_set: '[❤ Set the bonus](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&The type of bonus) [of the town %2% to %3%.](#00fb9a)'
 town_bonus_cleared: '[❤ The bonus](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&The type of bonus) [of %2% has been cleared.](#00fb9a)'
 town_bonus_list: '[❤ List of town bonuses for %1%:](#00fb9a)'

--- a/common/src/main/resources/locales/es-es.yml
+++ b/common/src/main/resources/locales/es-es.yml
@@ -141,7 +141,7 @@ town_chat_talking: '[Estas escribiendo en el chat de la ciudad.](#00fb9a) [[☄ 
 town_chat_not_talking: '[Ya no estas escribiendo en el chat de la ciudad.](#00fb9a) [[☄ Cambiar…]](#c8ff00 show_text=&#c8ff00&Click para cambiar chat de ciudad suggest_command=/husktowns:town chat)'
 town_chat_message_format: '[[%1%]](%2% show_text=&%2%&Mensaje en el chat de la ciudad) [%3%:](gray show_text=&7%4%) %5%'
 town_chat_spy_message_format: '[[%1%/Spy]](gray show_text=&7Town chat message) [%2%:](gray show_text=&7%3%) [%4%](dark_gray)'
-town_player_info: '[%1% is currently a member of](#00fb9a) [%2%](#00fb9a bold show_text=&#00fb9a&%2%\n&#55ff2b&⚓ Level: %5%\n&#ffc62b&⛨ Coffers: %6%\n&%4%&█ Claims: %7%/%8%\n&#b0ff55&☻ Population: %9%/%10%\n\n&7%11% run_command=/husktowns:town info %2%) [and is a %3%.](#00fb9a) [[⚓ More info…]](%4% show_text=&%4%&Click to view an overview of %2% run_command=/husktowns:town info %2%)'
+town_player_info: '[%1% is currently a member of](#00fb9a) [%2%](#00fb9a bold show_text=&#00fb9a&%2%\n&#55ff2b&⚓ Level: %5%\n&#ffc62b&⛨ Coffers: %6%\n&%4%&█ Claims: %7%/%8%\n&#b0ff55&☻ Population: %9%/%10%\n\n&7✎ Bio: %11% run_command=/husktowns:town info %2%) [and is a %3%.](#00fb9a) [[⚓ More info…]](%4% show_text=&%4%&Click to view an overview of %2% run_command=/husktowns:town info %2%)'
 town_player_info_not_in_town: '[%1% is not currently a member of any town.](#00fb9a)'
 town_bonus_set: '[❤ Set the bonus](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&The type of bonus) [of the town %2% to %3%.](#00fb9a)'
 town_bonus_cleared: '[❤ The bonus](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&The type of bonus) [of %2% has been cleared.](#00fb9a)'

--- a/common/src/main/resources/locales/es-es.yml
+++ b/common/src/main/resources/locales/es-es.yml
@@ -141,6 +141,8 @@ town_chat_talking: '[Estas escribiendo en el chat de la ciudad.](#00fb9a) [[☄ 
 town_chat_not_talking: '[Ya no estas escribiendo en el chat de la ciudad.](#00fb9a) [[☄ Cambiar…]](#c8ff00 show_text=&#c8ff00&Click para cambiar chat de ciudad suggest_command=/husktowns:town chat)'
 town_chat_message_format: '[[%1%]](%2% show_text=&%2%&Mensaje en el chat de la ciudad) [%3%:](gray show_text=&7%4%) %5%'
 town_chat_spy_message_format: '[[%1%/Spy]](gray show_text=&7Town chat message) [%2%:](gray show_text=&7%3%) [%4%](dark_gray)'
+town_player_info: '[%1% is currently a member of](#00fb9a) [%2%](#00fb9a bold show_text=&#00fb9a&%2%\n&#55ff2b&⚓ Level: %5%\n&#ffc62b&⛨ Coffers: %6%\n&%4%&█ Claims: %7%/%8%\n&#b0ff55&☻ Population: %9%/%10%\n\n&7%11% run_command=/husktowns:town info %2%) [and is a %3%.](#00fb9a) [[⚓ More info…]](%4% show_text=&%4%&Click to view an overview of %2% run_command=/husktowns:town info %2%)'
+town_player_info_not_in_town: '[%1% is not currently a member of any town.](#00fb9a)'
 town_bonus_set: '[❤ Set the bonus](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&The type of bonus) [of the town %2% to %3%.](#00fb9a)'
 town_bonus_cleared: '[❤ The bonus](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&The type of bonus) [of %2% has been cleared.](#00fb9a)'
 town_bonus_list: '[❤ List of town bonuses for %1%:](#00fb9a)'

--- a/common/src/main/resources/locales/es-es.yml
+++ b/common/src/main/resources/locales/es-es.yml
@@ -141,7 +141,7 @@ town_chat_talking: '[Estas escribiendo en el chat de la ciudad.](#00fb9a) [[☄ 
 town_chat_not_talking: '[Ya no estas escribiendo en el chat de la ciudad.](#00fb9a) [[☄ Cambiar…]](#c8ff00 show_text=&#c8ff00&Click para cambiar chat de ciudad suggest_command=/husktowns:town chat)'
 town_chat_message_format: '[[%1%]](%2% show_text=&%2%&Mensaje en el chat de la ciudad) [%3%:](gray show_text=&7%4%) %5%'
 town_chat_spy_message_format: '[[%1%/Spy]](gray show_text=&7Town chat message) [%2%:](gray show_text=&7%3%) [%4%](dark_gray)'
-town_player_info: '[%1% is currently a member of](#00fb9a) [%2%](#00fb9a bold show_text=&#00fb9a&%2%\n&#55ff2b&⚓ Level: %5%\n&#ffc62b&⛨ Coffers: %6%\n&%4%&█ Claims: %7%/%8%\n&#b0ff55&☻ Population: %9%/%10%\n\n&7✎ Bio: %11% run_command=/husktowns:town info %2%) [and is a %3%.](#00fb9a) [[⚓ More info…]](%4% show_text=&%4%&Click to view an overview of %2% run_command=/husktowns:town info %2%)'
+town_player_info: '[%1% is currently a %3% of](#00fb9a) [%2%](#00fb9a bold show_text=&#00fb9a&%2%\n&#55ff2b&⚓ Level: %5%\n&#ffc62b&⛨ Coffers: %6%\n&%4%&█ Claims: %7%/%8%\n&#b0ff55&☻ Population: %9%/%10%\n\n&7✎ Bio: %11% run_command=/husktowns:town info %2%) [[⚓ More info…]](%4% show_text=&%4%&Click to view an overview of %2% run_command=/husktowns:town info %2%)'
 town_player_info_not_in_town: '[%1% is not currently a member of any town.](#00fb9a)'
 town_bonus_set: '[❤ Set the bonus](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&The type of bonus) [of the town %2% to %3%.](#00fb9a)'
 town_bonus_cleared: '[❤ The bonus](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&The type of bonus) [of %2% has been cleared.](#00fb9a)'

--- a/common/src/main/resources/locales/tr-tr.yml
+++ b/common/src/main/resources/locales/tr-tr.yml
@@ -141,7 +141,7 @@ town_chat_talking: '[Kasaba sohbetinde konuşuyorsun.](#00fb9a) [[☄ Aç/Kapat�
 town_chat_not_talking: '[Kasaba sohbeti kapatıldı.](#00fb9a) [[☄ Aç/Kapat…]](#c8ff00 show_text=&#c8ff00&Kasaba sohbetini Açmak/Kapatmak için tıklayın suggest_command=/husktowns:town chat)'
 town_chat_message_format: '[[%1%]](%2% show_text=&%2%&Kasaba sohbet mesajı) [%3%:](gray show_text=&7%4%) %5%'
 town_chat_spy_message_format: '[[%1%/KasabaCasus]](gray show_text=&7Kasaba sohbet mesajı) [%2%:](gray show_text=&7%3%) [%4%](dark_gray)'
-town_player_info: '[%1% is currently a member of](#00fb9a) [%2%](#00fb9a bold show_text=&#00fb9a&%2%\n&#55ff2b&⚓ Level: %5%\n&#ffc62b&⛨ Coffers: %6%\n&%4%&█ Claims: %7%/%8%\n&#b0ff55&☻ Population: %9%/%10%\n\n&7%11% run_command=/husktowns:town info %2%) [and is a %3%.](#00fb9a) [[⚓ More info…]](%4% show_text=&%4%&Click to view an overview of %2% run_command=/husktowns:town info %2%)'
+town_player_info: '[%1% is currently a member of](#00fb9a) [%2%](#00fb9a bold show_text=&#00fb9a&%2%\n&#55ff2b&⚓ Level: %5%\n&#ffc62b&⛨ Coffers: %6%\n&%4%&█ Claims: %7%/%8%\n&#b0ff55&☻ Population: %9%/%10%\n\n&7✎ Bio: %11% run_command=/husktowns:town info %2%) [and is a %3%.](#00fb9a) [[⚓ More info…]](%4% show_text=&%4%&Click to view an overview of %2% run_command=/husktowns:town info %2%)'
 town_player_info_not_in_town: '[%1% is not currently a member of any town.](#00fb9a)'
 town_bonus_set: '[❤ Bonus ayarla](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&Bonus türü) [%2% kasabasının bonusunu %3% olarak ayarla.](#00fb9a)'
 town_bonus_cleared: '[❤ Bonus](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&Bonus türü:) [%2% kaldırıldı.](#00fb9a)'

--- a/common/src/main/resources/locales/tr-tr.yml
+++ b/common/src/main/resources/locales/tr-tr.yml
@@ -141,7 +141,7 @@ town_chat_talking: '[Kasaba sohbetinde konuşuyorsun.](#00fb9a) [[☄ Aç/Kapat�
 town_chat_not_talking: '[Kasaba sohbeti kapatıldı.](#00fb9a) [[☄ Aç/Kapat…]](#c8ff00 show_text=&#c8ff00&Kasaba sohbetini Açmak/Kapatmak için tıklayın suggest_command=/husktowns:town chat)'
 town_chat_message_format: '[[%1%]](%2% show_text=&%2%&Kasaba sohbet mesajı) [%3%:](gray show_text=&7%4%) %5%'
 town_chat_spy_message_format: '[[%1%/KasabaCasus]](gray show_text=&7Kasaba sohbet mesajı) [%2%:](gray show_text=&7%3%) [%4%](dark_gray)'
-town_player_info: '[%1% is currently a member of](#00fb9a) [%2%](#00fb9a bold show_text=&#00fb9a&%2%\n&#55ff2b&⚓ Level: %5%\n&#ffc62b&⛨ Coffers: %6%\n&%4%&█ Claims: %7%/%8%\n&#b0ff55&☻ Population: %9%/%10%\n\n&7✎ Bio: %11% run_command=/husktowns:town info %2%) [and is a %3%.](#00fb9a) [[⚓ More info…]](%4% show_text=&%4%&Click to view an overview of %2% run_command=/husktowns:town info %2%)'
+town_player_info: '[%1% is currently a %3% of](#00fb9a) [%2%](#00fb9a bold show_text=&#00fb9a&%2%\n&#55ff2b&⚓ Level: %5%\n&#ffc62b&⛨ Coffers: %6%\n&%4%&█ Claims: %7%/%8%\n&#b0ff55&☻ Population: %9%/%10%\n\n&7✎ Bio: %11% run_command=/husktowns:town info %2%) [[⚓ More info…]](%4% show_text=&%4%&Click to view an overview of %2% run_command=/husktowns:town info %2%)'
 town_player_info_not_in_town: '[%1% is not currently a member of any town.](#00fb9a)'
 town_bonus_set: '[❤ Bonus ayarla](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&Bonus türü) [%2% kasabasının bonusunu %3% olarak ayarla.](#00fb9a)'
 town_bonus_cleared: '[❤ Bonus](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&Bonus türü:) [%2% kaldırıldı.](#00fb9a)'

--- a/common/src/main/resources/locales/tr-tr.yml
+++ b/common/src/main/resources/locales/tr-tr.yml
@@ -141,6 +141,8 @@ town_chat_talking: '[Kasaba sohbetinde konuşuyorsun.](#00fb9a) [[☄ Aç/Kapat�
 town_chat_not_talking: '[Kasaba sohbeti kapatıldı.](#00fb9a) [[☄ Aç/Kapat…]](#c8ff00 show_text=&#c8ff00&Kasaba sohbetini Açmak/Kapatmak için tıklayın suggest_command=/husktowns:town chat)'
 town_chat_message_format: '[[%1%]](%2% show_text=&%2%&Kasaba sohbet mesajı) [%3%:](gray show_text=&7%4%) %5%'
 town_chat_spy_message_format: '[[%1%/KasabaCasus]](gray show_text=&7Kasaba sohbet mesajı) [%2%:](gray show_text=&7%3%) [%4%](dark_gray)'
+town_player_info: '[%1% is currently a member of](#00fb9a) [%2%](#00fb9a bold show_text=&#00fb9a&%2%\n&#55ff2b&⚓ Level: %5%\n&#ffc62b&⛨ Coffers: %6%\n&%4%&█ Claims: %7%/%8%\n&#b0ff55&☻ Population: %9%/%10%\n\n&7%11% run_command=/husktowns:town info %2%) [and is a %3%.](#00fb9a) [[⚓ More info…]](%4% show_text=&%4%&Click to view an overview of %2% run_command=/husktowns:town info %2%)'
+town_player_info_not_in_town: '[%1% is not currently a member of any town.](#00fb9a)'
 town_bonus_set: '[❤ Bonus ayarla](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&Bonus türü) [%2% kasabasının bonusunu %3% olarak ayarla.](#00fb9a)'
 town_bonus_cleared: '[❤ Bonus](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&Bonus türü:) [%2% kaldırıldı.](#00fb9a)'
 town_bonus_list: '[❤ %1% Kasaba bonus listesi:](#00fb9a)'

--- a/common/src/main/resources/locales/zh-cn.yml
+++ b/common/src/main/resources/locales/zh-cn.yml
@@ -141,7 +141,7 @@ town_chat_talking: '[你现在使用城镇私聊频道.](#00fb9a) [[☄ 切换�
 town_chat_not_talking: '[你现在不再使用城镇私聊.](#00fb9a) [[☄ 切换…]](#c8ff00 show_text=&#c8ff00&切换是否使用城镇聊天 suggest_command=/husktowns:town chat)'
 town_chat_message_format: '[[%1%]](%2% show_text=&%2%&城镇私密频道) [%3%:](gray show_text=&7%4%) %5%'
 town_chat_spy_message_format: '[[%1%/Spy]](gray show_text=&7城镇聊天) [%2%:](gray show_text=&7%3%) [%4%](dark_gray)'
-town_player_info: '[%1% is currently a member of](#00fb9a) [%2%](#00fb9a bold show_text=&#00fb9a&%2%\n&#55ff2b&⚓ Level: %5%\n&#ffc62b&⛨ Coffers: %6%\n&%4%&█ Claims: %7%/%8%\n&#b0ff55&☻ Population: %9%/%10%\n\n&7%11% run_command=/husktowns:town info %2%) [and is a %3%.](#00fb9a) [[⚓ More info…]](%4% show_text=&%4%&Click to view an overview of %2% run_command=/husktowns:town info %2%)'
+town_player_info: '[%1% is currently a member of](#00fb9a) [%2%](#00fb9a bold show_text=&#00fb9a&%2%\n&#55ff2b&⚓ Level: %5%\n&#ffc62b&⛨ Coffers: %6%\n&%4%&█ Claims: %7%/%8%\n&#b0ff55&☻ Population: %9%/%10%\n\n&7✎ Bio: %11% run_command=/husktowns:town info %2%) [and is a %3%.](#00fb9a) [[⚓ More info…]](%4% show_text=&%4%&Click to view an overview of %2% run_command=/husktowns:town info %2%)'
 town_player_info_not_in_town: '[%1% is not currently a member of any town.](#00fb9a)'
 town_bonus_set: '[❤ 设置奖励](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&奖励类型) [给城镇 %2% 为 %3%.](#00fb9a)'
 town_bonus_cleared: '[❤ 奖励](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&奖励类型) [城镇 %2% 被删除.](#00fb9a)'

--- a/common/src/main/resources/locales/zh-cn.yml
+++ b/common/src/main/resources/locales/zh-cn.yml
@@ -141,7 +141,7 @@ town_chat_talking: '[你现在使用城镇私聊频道.](#00fb9a) [[☄ 切换�
 town_chat_not_talking: '[你现在不再使用城镇私聊.](#00fb9a) [[☄ 切换…]](#c8ff00 show_text=&#c8ff00&切换是否使用城镇聊天 suggest_command=/husktowns:town chat)'
 town_chat_message_format: '[[%1%]](%2% show_text=&%2%&城镇私密频道) [%3%:](gray show_text=&7%4%) %5%'
 town_chat_spy_message_format: '[[%1%/Spy]](gray show_text=&7城镇聊天) [%2%:](gray show_text=&7%3%) [%4%](dark_gray)'
-town_player_info: '[%1% is currently a member of](#00fb9a) [%2%](#00fb9a bold show_text=&#00fb9a&%2%\n&#55ff2b&⚓ Level: %5%\n&#ffc62b&⛨ Coffers: %6%\n&%4%&█ Claims: %7%/%8%\n&#b0ff55&☻ Population: %9%/%10%\n\n&7✎ Bio: %11% run_command=/husktowns:town info %2%) [and is a %3%.](#00fb9a) [[⚓ More info…]](%4% show_text=&%4%&Click to view an overview of %2% run_command=/husktowns:town info %2%)'
+town_player_info: '[%1% is currently a %3% of](#00fb9a) [%2%](#00fb9a bold show_text=&#00fb9a&%2%\n&#55ff2b&⚓ Level: %5%\n&#ffc62b&⛨ Coffers: %6%\n&%4%&█ Claims: %7%/%8%\n&#b0ff55&☻ Population: %9%/%10%\n\n&7✎ Bio: %11% run_command=/husktowns:town info %2%) [[⚓ More info…]](%4% show_text=&%4%&Click to view an overview of %2% run_command=/husktowns:town info %2%)'
 town_player_info_not_in_town: '[%1% is not currently a member of any town.](#00fb9a)'
 town_bonus_set: '[❤ 设置奖励](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&奖励类型) [给城镇 %2% 为 %3%.](#00fb9a)'
 town_bonus_cleared: '[❤ 奖励](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&奖励类型) [城镇 %2% 被删除.](#00fb9a)'

--- a/common/src/main/resources/locales/zh-cn.yml
+++ b/common/src/main/resources/locales/zh-cn.yml
@@ -141,6 +141,8 @@ town_chat_talking: '[你现在使用城镇私聊频道.](#00fb9a) [[☄ 切换�
 town_chat_not_talking: '[你现在不再使用城镇私聊.](#00fb9a) [[☄ 切换…]](#c8ff00 show_text=&#c8ff00&切换是否使用城镇聊天 suggest_command=/husktowns:town chat)'
 town_chat_message_format: '[[%1%]](%2% show_text=&%2%&城镇私密频道) [%3%:](gray show_text=&7%4%) %5%'
 town_chat_spy_message_format: '[[%1%/Spy]](gray show_text=&7城镇聊天) [%2%:](gray show_text=&7%3%) [%4%](dark_gray)'
+town_player_info: '[%1% is currently a member of](#00fb9a) [%2%](#00fb9a bold show_text=&#00fb9a&%2%\n&#55ff2b&⚓ Level: %5%\n&#ffc62b&⛨ Coffers: %6%\n&%4%&█ Claims: %7%/%8%\n&#b0ff55&☻ Population: %9%/%10%\n\n&7%11% run_command=/husktowns:town info %2%) [and is a %3%.](#00fb9a) [[⚓ More info…]](%4% show_text=&%4%&Click to view an overview of %2% run_command=/husktowns:town info %2%)'
+town_player_info_not_in_town: '[%1% is not currently a member of any town.](#00fb9a)'
 town_bonus_set: '[❤ 设置奖励](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&奖励类型) [给城镇 %2% 为 %3%.](#00fb9a)'
 town_bonus_cleared: '[❤ 奖励](#00fb9a) [%1%](#00fb9a italic show_text=&#00fb9a&奖励类型) [城镇 %2% 被删除.](#00fb9a)'
 town_bonus_list: '[❤ 城镇奖励列表 %1%:](#00fb9a)'

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -34,6 +34,7 @@ The `/town` command (base permission: `husktowns.command.town`) is the entry poi
 | `/town clearspawn` | Clear the town spawn                        | `husktowns.command.town.clearspawn` |
 | `/town privacy`    | Edit the privacy of the town spawn          | `husktowns.command.town.privacy`    |
 | `/town chat`       | Send a message to the town chat             | `husktowns.command.town.chat`       |
+| `/town player`     | View which town a player is a member of     | `husktowns.command.town.player`     |
 | `/town deeds`      | View a list of town claims on this server   | `husktowns.command.town.deeds`      |
 | `/town census`     | View a list of town members and their roles | `husktowns.command.town.census`     |
 | `/town log`        | View the town audit log                     | `husktowns.command.town.log`        |

--- a/paper/build.gradle
+++ b/paper/build.gradle
@@ -47,6 +47,6 @@ shadowJar {
 
 tasks {
     runServer {
-        minecraftVersion('1.20')
+        minecraftVersion('1.20.1')
     }
 }


### PR DESCRIPTION
Re-adds `/town player` (absent since v2.0), which lets you view which town a player is a member of, and what role they have in said town.

Usage: `/town player <player>`
Aliases: `/town who`
Permission: `husktowns.command.town.player`