### PR TITLE
Fix a critical issue, two minor issues

### DIFF
--- a/bukkit/src/main/java/net/william278/husktowns/BukkitHuskTowns.java
+++ b/bukkit/src/main/java/net/william278/husktowns/BukkitHuskTowns.java
@@ -126,10 +126,12 @@ public class BukkitHuskTowns extends JavaPlugin implements HuskTowns, BukkitTask
 
     @Override
     public void onEnable() {
-        // Enable HuskTowns and load configuration
-        this.loadConfig();
-        this.audiences = BukkitAudiences.create(this);
+        // Initialize PaperLib and Adventure
         this.paperLib = new MorePaperLib(this);
+        this.audiences = BukkitAudiences.create(this);
+
+        // Load configuration and subsystems
+        this.loadConfig();
         this.operationHandler = new OperationHandler(this);
         this.validator = new Validator(this);
         this.invites = new HashMap<>();

--- a/common/src/main/java/net/william278/husktowns/advancement/Reward.java
+++ b/common/src/main/java/net/william278/husktowns/advancement/Reward.java
@@ -52,14 +52,14 @@ public class Reward {
         switch (type) {
             case TOWN_LEVELS -> plugin.getUserTown(user).ifPresent(member -> plugin.getManager()
                     .editTown(user, member.town(), town -> {
-                        final BigDecimal quantity = BigDecimal.valueOf(this.quantity);
                         town.getLog().log(Action.of(user, Action.Type.ADVANCEMENT_REWARD_LEVELS, "Leveled up: " + quantity));
-                        town.setMoney(town.getMoney().add(quantity));
+                        town.setLevel(Math.min(plugin.getLevels().getMaxLevel(), town.getLevel() + quantity));
                     }));
             case TOWN_MONEY -> plugin.getUserTown(user).ifPresent(member -> plugin.getManager()
                     .editTown(user, member.town(), town -> {
+                        final BigDecimal quantity = BigDecimal.valueOf(this.quantity);
                         town.getLog().log(Action.of(user, Action.Type.ADVANCEMENT_REWARD_MONEY, "Awarded: " + quantity));
-                        town.setLevel(Math.min(plugin.getLevels().getMaxLevel(), town.getLevel() + quantity));
+                        town.setMoney(town.getMoney().add(quantity));
                     }));
             case TOWN_BONUS_CLAIMS -> plugin.getUserTown(user).ifPresent(member -> plugin.getManager()
                     .editTown(user, member.town(), town -> {

--- a/common/src/main/java/net/william278/husktowns/advancement/Variable.java
+++ b/common/src/main/java/net/william278/husktowns/advancement/Variable.java
@@ -44,7 +44,8 @@ public class Variable<T> {
     public static final Variable<Integer> TOWN_UNIQUE_DEPOSITORS = create(
             "unique_depositors",
             (town, onlineUser, uniqueDepositors) -> Math.toIntExact((town.getLog().getActions().values().stream()
-                    .filter(action -> action.getType() == Action.Type.DEPOSIT_MONEY).map(Action::getUser).distinct().count() - uniqueDepositors)),
+                    .filter(action -> action.getType() == Action.Type.DEPOSIT_MONEY)
+                    .map(Action::getUser).distinct().count() - uniqueDepositors)),
             Integer.class
     );
     public static final Variable<Integer> TOWN_MEMBERS = create(

--- a/common/src/main/java/net/william278/husktowns/database/Database.java
+++ b/common/src/main/java/net/william278/husktowns/database/Database.java
@@ -121,7 +121,7 @@ public abstract class Database {
                         executeScript(connection, scriptName);
                     } catch (SQLException e) {
                         plugin.log(Level.WARNING, "Migration " + migration.getMigrationName()
-                                + " (v" + migration.getVersion() + " failed; skipping", e);
+                                + " (v" + migration.getVersion() + ") failed; skipping", e);
                     }
                 }
             }

--- a/common/src/main/java/net/william278/husktowns/database/MySqlDatabase.java
+++ b/common/src/main/java/net/william278/husktowns/database/MySqlDatabase.java
@@ -119,14 +119,17 @@ public final class MySqlDatabase extends Database {
         // Create tables
         final Database.Type type = plugin.getSettings().getDatabaseType();
         if (!isCreated()) {
+            plugin.log(Level.INFO, String.format("Creating %s database tables", type.getDisplayName()));
             try (Connection connection = getConnection()) {
                 executeScript(connection, String.format("%s_schema.sql", flavor));
-                setLoaded(true);
             } catch (SQLException e) {
                 plugin.log(Level.SEVERE, String.format("Failed to create %s database tables", type.getDisplayName()));
                 setLoaded(false);
                 return;
             }
+            setSchemaVersion(Migration.getLatestVersion());
+            plugin.log(Level.INFO, String.format("Created %s database tables", type.getDisplayName()));
+            setLoaded(true);
             return;
         }
 

--- a/common/src/main/java/net/william278/husktowns/database/SqLiteDatabase.java
+++ b/common/src/main/java/net/william278/husktowns/database/SqLiteDatabase.java
@@ -114,14 +114,17 @@ public final class SqLiteDatabase extends Database {
 
         // Create tables
         if (!isCreated()) {
+            plugin.log(Level.INFO, "Creating SQLite database tables");
             try {
                 executeScript(getConnection(), "sqlite_schema.sql");
-                setLoaded(true);
             } catch (SQLException e) {
                 plugin.log(Level.SEVERE, "Failed to create SQLite database tables");
                 setLoaded(false);
                 return;
             }
+            setSchemaVersion(Migration.getLatestVersion());
+            plugin.log(Level.INFO, "SQLite database tables created!");
+            setLoaded(true);
             return;
         }
 

--- a/common/src/main/java/net/william278/husktowns/manager/TownsManager.java
+++ b/common/src/main/java/net/william278/husktowns/manager/TownsManager.java
@@ -239,7 +239,7 @@ public class TownsManager {
 
         // Reply to the sender
         plugin.getOnlineUsers().stream()
-                .filter(online -> online.getUuid().equals(invite.getSender().getUuid())).findFirst()
+                .filter(online -> online.equals(invite.getSender())).findFirst()
                 .ifPresent(sender -> plugin.getLocales().getLocale("invite_declined_by", user.getUsername())
                         .ifPresent(sender::sendMessage));
 
@@ -348,7 +348,7 @@ public class TownsManager {
                                 town.getName()).ifPresent(user::sendMessage);
 
                         plugin.getOnlineUsers().stream()
-                                .filter(online -> online.getUuid().equals(evicted.get().getUuid()))
+                                .filter(online -> online.equals(evicted.get()))
                                 .findFirst()
                                 .ifPresentOrElse(onlineUser -> plugin.getLocales()
                                                 .getLocale("evicted_you", town.getName(), user.getUsername())
@@ -394,7 +394,7 @@ public class TownsManager {
                                 promoted.get().getUsername(), newRole.getName()).ifPresent(user::sendMessage);
 
                         plugin.getOnlineUsers().stream()
-                                .filter(online -> online.getUuid().equals(promoted.get().getUuid()))
+                                .filter(online -> online.equals(promoted.get()))
                                 .findFirst()
                                 .ifPresentOrElse(onlineUser -> plugin.getLocales()
                                                 .getLocale("promoted_you", newRole.getName(), user.getUsername())
@@ -447,7 +447,7 @@ public class TownsManager {
                                 demoted.get().getUsername(), newRole.getName()).ifPresent(user::sendMessage);
 
                         plugin.getOnlineUsers().stream()
-                                .filter(online -> online.getUuid().equals(demoted.get().getUuid()))
+                                .filter(online -> online.equals(demoted.get()))
                                 .findFirst()
                                 .ifPresentOrElse(onlineUser -> plugin.getLocales()
                                                 .getLocale("demoted_you", newRole.getName(), user.getUsername())

--- a/common/src/main/java/net/william278/husktowns/user/User.java
+++ b/common/src/main/java/net/william278/husktowns/user/User.java
@@ -54,4 +54,13 @@ public class User {
     public String getUsername() {
         return username;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof User user)) {
+            return false;
+        }
+        return user.getUuid().equals(uuid);
+    }
+
 }


### PR DESCRIPTION
Closes #296

This PR addresses a critical issue with the town advancement system.

* Fixed a critical issue with the town advancement system awarding levels instead of money for unique depositors (#296)
* Fixed the unique depositors advancement condition not being calculated correctly (making the effect of the above even worse)
* Fixed the schema version of the database not being set after initial creation, causing warnings in console on the second boot