### PR TITLE
Fix exception generating map hook chunk highlights for towns with UTF-8 names

### DIFF
--- a/common/src/main/java/net/william278/husktowns/hook/BlueMapHook.java
+++ b/common/src/main/java/net/william278/husktowns/hook/BlueMapHook.java
@@ -97,7 +97,7 @@ public final class BlueMapHook extends MapHook {
     @NotNull
     private String getClaimMarkerKey(@NotNull TownClaim claim) {
         return plugin.getKey(
-                claim.town().getName().toLowerCase(),
+                Integer.toString(claim.town().getId()),
                 Integer.toString(claim.claim().getChunk().getX()),
                 Integer.toString(claim.claim().getChunk().getZ())
         ).toString();

--- a/common/src/main/java/net/william278/husktowns/hook/DynmapHook.java
+++ b/common/src/main/java/net/william278/husktowns/hook/DynmapHook.java
@@ -86,8 +86,13 @@ public class DynmapHook extends MapHook {
             z[3] = (chunk.getZ() * 16) + 16;
 
             // Define the marker
-            marker = markerSet.createAreaMarker(markerId, claim.town().getName(), false,
-                    world.getName(), x, z, false);
+            marker = markerSet.createAreaMarker(
+                    markerId,
+                    claim.town().getName(),
+                    false,
+                    world.getName(), x, z,
+                    false
+            );
         }
 
         // Set the marker y level
@@ -143,7 +148,7 @@ public class DynmapHook extends MapHook {
     @NotNull
     private String getClaimMarkerKey(@NotNull TownClaim claim, @NotNull World world) {
         return plugin.getKey(
-                claim.town().getName().toLowerCase(),
+                Integer.toString(claim.town().getId()),
                 Integer.toString(claim.claim().getChunk().getX()),
                 Integer.toString(claim.claim().getChunk().getZ()),
                 world.getName()
@@ -158,8 +163,12 @@ public class DynmapHook extends MapHook {
         return getDynmap().map(api -> {
             markerSet = api.getMarkerAPI().getMarkerSet(getMarkerSetKey());
             if (markerSet == null) {
-                markerSet = api.getMarkerAPI().createMarkerSet(getMarkerSetKey(), plugin.getSettings().getWebMapMarkerSetName(),
-                        api.getMarkerAPI().getMarkerIcons(), false);
+                markerSet = api.getMarkerAPI().createMarkerSet(
+                        getMarkerSetKey(),
+                        plugin.getSettings().getWebMapMarkerSetName(),
+                        api.getMarkerAPI().getMarkerIcons(),
+                        false
+                );
             } else {
                 markerSet.setMarkerSetLabel(plugin.getSettings().getWebMapMarkerSetName());
             }

--- a/common/src/main/java/net/william278/husktowns/hook/Pl3xMapHook.java
+++ b/common/src/main/java/net/william278/husktowns/hook/Pl3xMapHook.java
@@ -111,7 +111,7 @@ public class Pl3xMapHook extends MapHook {
     @NotNull
     private String getClaimMarkerKey(@NotNull TownClaim claim, @NotNull net.pl3x.map.core.world.World world) {
         return plugin.getKey(
-                claim.town().getName().toLowerCase(),
+                Integer.toString(claim.town().getId()),
                 Integer.toString(claim.claim().getChunk().getX()),
                 Integer.toString(claim.claim().getChunk().getZ()),
                 world.getName()

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ javaVersion=16
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 org.gradle.daemon=true
 
-plugin_version=2.6
+plugin_version=2.6.1
 plugin_archive=husktowns
 plugin_description=Simple and elegant proxy-compatible Towny-style protection
 


### PR DESCRIPTION
Closes #374

Marker IDs now use the town ID rather than their name.