### PR TITLE
Add more placeholders

### DIFF
--- a/bukkit/src/main/java/net/william278/husktowns/hook/PlaceholderAPIHook.java
+++ b/bukkit/src/main/java/net/william278/husktowns/hook/PlaceholderAPIHook.java
@@ -37,6 +37,9 @@ import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -54,6 +57,17 @@ public class PlaceholderAPIHook extends Hook {
 
         private static final String NOT_IN_TOWN_COLOR = "#aaaaaa";
         private static final String WILDERNESS_COLOR = "#2e2e2e";
+        private static final BigDecimal THOUSAND = BigDecimal.valueOf(1000);
+        private static final String DECIMAL_FORMAT = "#.#";
+        private static final TreeMap<BigDecimal, String> NUMBER_FORMAT = new TreeMap<>();
+
+        static {
+            NUMBER_FORMAT.put(THOUSAND, "k");
+            NUMBER_FORMAT.put(THOUSAND.pow(2), "M");
+            NUMBER_FORMAT.put(THOUSAND.pow(3), "G");
+            NUMBER_FORMAT.put(THOUSAND.pow(4), "T");
+            NUMBER_FORMAT.put(THOUSAND.pow(5), "Q");
+        }
 
         @NotNull
         private final HuskTowns plugin;
@@ -68,6 +82,13 @@ public class PlaceholderAPIHook extends Hook {
                 return plugin.getLocales().getNotApplicable();
             }
 
+            if (params.startsWith("town_leaderboard_")) {
+                if (params.length() == 17) {
+                    return null;
+                }
+                return getTownLeaderboard(params.substring(17));
+            }
+
             // Ensure the player is online
             if (offlinePlayer == null || !offlinePlayer.isOnline() || offlinePlayer.getPlayer() == null) {
                 return plugin.getLocales().getRawLocale("placeholder_player_offline")
@@ -76,127 +97,74 @@ public class PlaceholderAPIHook extends Hook {
 
             // Return the requested placeholder
             final OnlineUser player = BukkitUser.adapt(offlinePlayer.getPlayer(), plugin);
-            return switch (params) {
-                case "town_name" -> plugin.getUserTown(player)
+
+            if (params.startsWith("town_")) {
+                if (params.length() == 5) {
+                    return null;
+                }
+                return getTown(player, params.substring(5));
+            }
+
+            if (params.startsWith("current_location_")) {
+                if (params.length() == 17) {
+                    return null;
+                }
+                return getCurrentLocation(player, params.substring(17));
+            }
+
+            return null;
+        }
+
+        @Nullable
+        private String getTown(@NotNull OnlineUser player, @NotNull String identifier) {
+            return switch (identifier) {
+                case "name" -> plugin.getUserTown(player)
                         .map(Member::town)
                         .map(Town::getName)
                         .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
                                 .orElse("Not in town"));
 
-                case "town_role" -> plugin.getUserTown(player)
+                case "role" -> plugin.getUserTown(player)
                         .map(Member::role)
                         .map(Role::getName)
                         .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
                                 .orElse("Not in town"));
 
-                case "town_mayor" -> plugin.getUserTown(player)
-                        .map(Member::town)
-                        .map(town -> resolveTownMemberName(town, town.getMayor()).orElse("?"))
-                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
-                                .orElse("Not in town"));
-
-                case "town_color" -> plugin.getUserTown(player)
+                case "color" -> plugin.getUserTown(player)
                         .map(Member::town)
                         .map(Town::getColorRgb)
                         .orElse(NOT_IN_TOWN_COLOR);
 
-                case "town_members" -> plugin.getUserTown(player)
+                default -> plugin.getUserTown(player)
                         .map(Member::town)
-                        .map(town -> town.getMembers().keySet().stream()
-                                .map(uuid -> resolveTownMemberName(town, uuid).orElse("?"))
-                                .collect(Collectors.joining(", ")))
-                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
-                                .orElse("Not in town"));
-
-                case "town_member_count" -> plugin.getUserTown(player)
-                        .map(Member::town)
-                        .map(Town::getMembers)
-                        .map(members -> String.valueOf(members.size()))
-                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
-                                .orElse("Not in town"));
-
-                case "town_claim_count" -> plugin.getUserTown(player)
-                        .map(Member::town)
-                        .map(Town::getClaimCount)
+                        .map(town -> resolveTownData(town, identifier))
                         .map(String::valueOf)
                         .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
                                 .orElse("Not in town"));
+            };
+        }
 
-                case "town_max_claims" -> plugin.getUserTown(player)
-                        .map(Member::town)
-                        .map(town -> town.getMaxClaims(plugin))
-                        .map(String::valueOf)
-                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
-                                .orElse("Not in town"));
-
-                case "town_max_members" -> plugin.getUserTown(player)
-                        .map(Member::town)
-                        .map(town -> town.getMaxMembers(plugin))
-                        .map(String::valueOf)
-                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
-                                .orElse("Not in town"));
-
-                case "town_crop_growth_rate" -> plugin.getUserTown(player)
-                        .map(Member::town)
-                        .map(town -> town.getCropGrowthRate(plugin))
-                        .map(String::valueOf)
-                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
-                                .orElse("Not in town"));
-
-                case "town_mob_spawner_rate" -> plugin.getUserTown(player)
-                        .map(Member::town)
-                        .map(town -> town.getMobSpawnerRate(plugin))
-                        .map(String::valueOf)
-                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
-                                .orElse("Not in town"));
-
-                case "town_money" -> plugin.getUserTown(player)
-                        .map(Member::town)
-                        .map(Town::getMoney)
-                        .map(plugin::formatMoney)
-                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
-                                .orElse("Not in town"));
-
-                case "town_level_up_cost" -> plugin.getUserTown(player)
-                        .map(Member::town)
-                        .map(town -> town.getLevel() >= plugin.getLevels().getMaxLevel()
-                                ? plugin.getLocales().getNotApplicable()
-                                : plugin.formatMoney(plugin.getLevels().getLevelUpCost(town.getLevel())))
-                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
-                                .orElse("Not in town"));
-
-                case "town_level" -> plugin.getUserTown(player)
-                        .map(Member::town)
-                        .map(Town::getLevel)
-                        .map(String::valueOf)
-                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
-                                .orElse("Not in town"));
-
-                case "town_max_level" -> plugin.getUserTown(player)
-                        .map(Member::town)
-                        .map(town -> plugin.getLevels().getMaxLevel())
-                        .map(String::valueOf)
-                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
-                                .orElse("Not in town"));
-
-                case "current_location_town" -> plugin.getClaimAt(player.getPosition())
+        @Nullable
+        public String getCurrentLocation(@NotNull OnlineUser player, @NotNull String identifier) {
+            return switch (identifier) {
+                case "town" -> plugin.getClaimAt(player.getPosition())
                         .map(TownClaim::town)
                         .map(Town::getName)
                         .orElse(plugin.getLocales().getRawLocale("placeholder_wilderness")
                                 .orElse("Wilderness"));
 
-                case "current_location_can_build" -> getBooleanValue(!plugin
+                case "can_build" -> getBooleanValue(!plugin
                         .cancelOperation(Operation.of(player, OperationType.BLOCK_PLACE, player.getPosition(), true)));
 
-                case "current_location_can_interact" -> getBooleanValue(!plugin.cancelOperation(
+                case "can_interact" -> getBooleanValue(!plugin.cancelOperation(
                         Operation.of(player, OperationType.BLOCK_INTERACT, player.getPosition(), true)
                 ));
 
-                case "current_location_can_open_containers" -> getBooleanValue(!plugin.cancelOperation(
+                case "can_open_containers" -> getBooleanValue(!plugin.cancelOperation(
                         Operation.of(player, OperationType.CONTAINER_OPEN, player.getPosition(), true)
                 ));
 
-                case "current_location_claim_type" -> plugin.getClaimAt(player.getPosition())
+                case "claim_type" -> plugin.getClaimAt(player.getPosition())
                         .map(TownClaim::claim)
                         .map(Claim::getType)
                         .map(Claim.Type::name)
@@ -204,7 +172,7 @@ public class PlaceholderAPIHook extends Hook {
                         .orElse(plugin.getLocales().getRawLocale("placeholder_wilderness")
                                 .orElse("Wilderness"));
 
-                case "current_location_plot_members" -> plugin.getClaimAt(player.getPosition())
+                case "plot_members" -> plugin.getClaimAt(player.getPosition())
                         .map(townClaim -> {
                             final Claim claim = townClaim.claim();
                             if (claim.getType() != Claim.Type.PLOT) {
@@ -219,7 +187,7 @@ public class PlaceholderAPIHook extends Hook {
                         .orElse(plugin.getLocales().getRawLocale("placeholder_not_claimed")
                                 .orElse("Not claimed"));
 
-                case "current_location_plot_managers" -> plugin.getClaimAt(player.getPosition())
+                case "plot_managers" -> plugin.getClaimAt(player.getPosition())
                         .map(townClaim -> {
                             final Claim claim = townClaim.claim();
                             if (claim.getType() != Claim.Type.PLOT) {
@@ -235,87 +203,46 @@ public class PlaceholderAPIHook extends Hook {
                         .orElse(plugin.getLocales().getRawLocale("placeholder_not_claimed")
                                 .orElse("Not claimed"));
 
-                case "current_location_town_color" -> plugin.getClaimAt(player.getPosition())
+                case "town_color" -> plugin.getClaimAt(player.getPosition())
                         .map(TownClaim::town)
                         .map(Town::getColorRgb)
                         .orElse(WILDERNESS_COLOR);
 
-                case "current_location_town_money" -> plugin.getClaimAt(player.getPosition())
+                default -> identifier.startsWith("town_") ? plugin.getClaimAt(player.getPosition())
                         .map(TownClaim::town)
-                        .map(Town::getMoney)
-                        .map(plugin::formatMoney)
-                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_claimed")
-                                .orElse("Not claimed"));
-
-                case "current_location_town_level" -> plugin.getClaimAt(player.getPosition())
-                        .map(TownClaim::town)
-                        .map(Town::getLevel)
+                        .map(town -> resolveTownData(town, identifier.substring(5)))
                         .map(String::valueOf)
                         .orElse(plugin.getLocales().getRawLocale("placeholder_not_claimed")
-                                .orElse("Not claimed"));
-
-                case "current_location_town_level_up_cost" -> plugin.getClaimAt(player.getPosition())
-                        .map(TownClaim::town)
-                        .map(town -> town.getLevel() >= plugin.getLevels().getMaxLevel()
-                                ? plugin.getLocales().getNotApplicable()
-                                : plugin.formatMoney(plugin.getLevels().getLevelUpCost(town.getLevel())))
-                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_in_town")
-                                .orElse("Not in town"));
-
-                case "current_location_town_max_claims" -> plugin.getClaimAt(player.getPosition())
-                        .map(TownClaim::town)
-                        .map(town -> town.getMaxClaims(plugin))
-                        .map(String::valueOf)
-                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_claimed")
-                                .orElse("Not claimed"));
-
-                case "current_location_town_max_members" -> plugin.getClaimAt(player.getPosition())
-                        .map(TownClaim::town)
-                        .map(town -> town.getMaxMembers(plugin))
-                        .map(String::valueOf)
-                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_claimed")
-                                .orElse("Not claimed"));
-
-                case "current_location_town_crop_growth_rate" -> plugin.getClaimAt(player.getPosition())
-                        .map(TownClaim::town)
-                        .map(town -> town.getCropGrowthRate(plugin))
-                        .map(String::valueOf)
-                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_claimed")
-                                .orElse("Not claimed"));
-
-                case "current_location_town_mob_spawner_rate" -> plugin.getClaimAt(player.getPosition())
-                        .map(TownClaim::town)
-                        .map(town -> town.getMobSpawnerRate(plugin))
-                        .map(String::valueOf)
-                        .orElse(plugin.getLocales().getRawLocale("placeholder_not_claimed")
-                                .orElse("Not claimed"));
-
-                default -> params.startsWith("town_leaderboard_") ? getTownLeaderboard(params.substring(17)) : null;
+                                .orElse("Not claimed")) : null;
             };
         }
 
         // Get a town leaderboard
         @Nullable
         private String getTownLeaderboard(@NotNull String identifier) {
-            // Get the identifier up to the last underscore
-            final int lastUnderscore = identifier.lastIndexOf('_');
-            if (lastUnderscore == -1) {
+            final String[] split = identifier.split("_", 3);
+            if (split.length < 2) {
                 return null;
             }
 
             // Get the leaderboard index and return the sorted list element at the index
             try {
-                final int leaderboardIndex = Math.max(1, Integer.parseInt(
-                        identifier.substring(lastUnderscore + 1)
-                ));
-                final List<Town> towns = getSortedTownList(identifier.substring(0, lastUnderscore));
+                final int leaderboardIndex = Math.max(1, Integer.parseInt(split[1]));
+                final List<Town> towns = getSortedTownList(split[0]);
                 if (towns == null) {
                     return null;
                 }
 
-                return towns.size() >= leaderboardIndex
-                        ? towns.get(leaderboardIndex - 1).getName()
-                        : plugin.getLocales().getNotApplicable();
+                if (towns.size() >= leaderboardIndex) {
+                    final Town town = towns.get(leaderboardIndex - 1);
+                    if (split.length > 2) {
+                        return String.valueOf(resolveTownData(town, split[2]));
+                    } else {
+                        return town.getName();
+                    }
+                } else {
+                    return plugin.getLocales().getNotApplicable();
+                }
             } catch (NumberFormatException e) {
                 return null;
             }
@@ -340,6 +267,16 @@ public class PlaceholderAPIHook extends Hook {
             };
         }
 
+        @NotNull
+        public static String formatNumber(@NotNull BigDecimal number) {
+            final Map.Entry<BigDecimal, String> format = NUMBER_FORMAT.floorEntry(number);
+            if (format != null) {
+                return new DecimalFormat(DECIMAL_FORMAT).format(number.divide(format.getKey().divide(THOUSAND, RoundingMode.DOWN), RoundingMode.DOWN).doubleValue() / 1000.0) + format.getValue();
+            } else {
+                return number.toString();
+            }
+        }
+
         // Resolve a cached town member name from a UUID
         private Optional<String> resolveTownMemberName(@NotNull Town town, @NotNull UUID uuid) {
             return town.getLog().getActions().values().stream()
@@ -347,6 +284,45 @@ public class PlaceholderAPIHook extends Hook {
                     .filter(user -> user.getUuid().equals(uuid))
                     .map(User::getUsername)
                     .findFirst();
+        }
+
+        @Nullable
+        public Object resolveTownData(@NotNull Town town, @NotNull String identifier) {
+            return switch (identifier) {
+                case "name" -> town.getName();
+
+                case "mayor" -> resolveTownMemberName(town, town.getMayor()).orElse("?");
+
+                case "members" -> town.getMembers().keySet().stream()
+                        .map(uuid -> resolveTownMemberName(town, uuid).orElse("?"))
+                        .collect(Collectors.joining(", "));
+
+                case "member_count" -> town.getMembers().size();
+
+                case "claim_count" -> town.getClaimCount();
+
+                case "max_claims" -> town.getMaxClaims(plugin);
+
+                case "max_members" -> town.getMaxMembers(plugin);
+
+                case "crop_growth_rate" -> town.getCropGrowthRate(plugin);
+
+                case "mob_spawner_rate" -> town.getMobSpawnerRate(plugin);
+
+                case "money" -> plugin.formatMoney(town.getMoney());
+
+                case "money_formatted" -> formatNumber(town.getMoney());
+
+                case "level_up_cost" -> town.getLevel() >= plugin.getLevels().getMaxLevel()
+                        ? plugin.getLocales().getNotApplicable()
+                        : plugin.formatMoney(plugin.getLevels().getLevelUpCost(town.getLevel()));
+
+                case "level" -> town.getLevel();
+
+                case "max_level" -> plugin.getLevels().getMaxLevel();
+
+                default -> null;
+            };
         }
 
         @Override


### PR DESCRIPTION
Just a little refactor, and some new placeholders

### Additions
* All the `current_location_town` and `town_leaderboard_{type}_{index}` placeholders now can get an extensive town information, like `mayor`, `members`, `member_count`, `claim_count`, `max_claims`, `max_members`, `crop_growth_rate`, `mob_spawner_rate`, `money`, `money_formatted`, `level_up_cost`, `level`, `max_level`.
* New `money_formatted` placeholder to get town money with a short formatting method, for example `1003000` will be converted to `1M3k`.

### Changes
* Leaderboard placeholders now can be parsed without providing a player.

### Examples
`%husktowns_town_leaderboard_money_1_money%` to get how much money have the `#1` town on money leaderboard (useful to set leaderboard information in holograms).
`%husktowns_current_location_town_money_formatted%` to get how much money have the town at current location as short formatted number (useful to show that information in a scoreboard).
