### PR TITLE
fix: NullPointerException on dynmap marker removal, username lookup in specific cases

### DIFF
--- a/common/src/main/java/net/william278/husktowns/database/SqLiteDatabase.java
+++ b/common/src/main/java/net/william278/husktowns/database/SqLiteDatabase.java
@@ -231,17 +231,23 @@ public final class SqLiteDatabase extends Database {
             WHERE `username` = ?"""))) {
             statement.setString(1, username);
             final ResultSet resultSet = statement.executeQuery();
-            if (resultSet.next()) {
+            SavedUser saved = null;
+            while (resultSet.next()) {
+                final OffsetDateTime dateTime = resultSet.getTimestamp("last_login").toLocalDateTime()
+                        .atOffset(OffsetDateTime.now().getOffset());
+                if (saved != null && saved.lastLogin().isAfter(dateTime)) {
+                    continue;
+                }
                 final UUID uuid = UUID.fromString(resultSet.getString("uuid"));
                 final String name = resultSet.getString("username");
                 final String preferences = new String(resultSet.getBytes("preferences"), StandardCharsets.UTF_8);
-                return Optional.of(new SavedUser(
-                    User.of(uuid, name),
-                    resultSet.getTimestamp("last_login").toLocalDateTime()
-                        .atOffset(OffsetDateTime.now().getOffset()),
-                    plugin.getPreferencesFromJson(preferences)
-                ));
+                saved = new SavedUser(
+                        User.of(uuid, name),
+                        dateTime,
+                        plugin.getPreferencesFromJson(preferences)
+                );
             }
+            return Optional.ofNullable(saved);
         } catch (SQLException e) {
             plugin.log(Level.SEVERE, "Failed to fetch user data from table by username", e);
         }

--- a/common/src/main/java/net/william278/husktowns/hook/map/DynmapHook.java
+++ b/common/src/main/java/net/william278/husktowns/hook/map/DynmapHook.java
@@ -110,7 +110,12 @@ public class DynmapHook extends MapHook {
     }
 
     private void removeMarker(@NotNull TownClaim claim, @NotNull World world) {
-        getMarkerSet().ifPresent(markerSet -> markerSet.findAreaMarker(getClaimMarkerKey(claim, world)).deleteMarker());
+        getMarkerSet().ifPresent(markerSet -> {
+            final AreaMarker marker = markerSet.findAreaMarker(getClaimMarkerKey(claim, world));
+            if (marker != null) {
+                marker.deleteMarker();
+            }
+        });
     }
 
 


### PR DESCRIPTION
### Bug Fixes
* Fix duplicated player data, this is a very specific problem that can be present on semi-premium servers where the player name is the same but there are 2 UUIDs on the database.
* Fix some `NullPointerException` trying to remove marker from Dynmap,