### PR TITLE
Schedule teleportAsync

### DIFF
--- a/bukkit/src/main/java/net/william278/husktowns/user/BukkitUser.java
+++ b/bukkit/src/main/java/net/william278/husktowns/user/BukkitUser.java
@@ -112,10 +112,14 @@ public final class BukkitUser extends OnlineUser {
 
     @Override
     public void teleportTo(@NotNull Position position) {
-        PaperLib.teleportAsync(player, new Location(Bukkit.getWorld(position.getWorld().getName()) == null
-            ? Bukkit.getWorld(position.getWorld().getUuid())
-            : Bukkit.getWorld(position.getWorld().getName()),
-            position.getX(), position.getY(), position.getZ(), position.getYaw(), position.getPitch()));
+        plugin.runSync(player, () -> {
+            final org.bukkit.World bukkitWorld = Bukkit.getWorld(position.getWorld().getName()) != null
+                ? Bukkit.getWorld(position.getWorld().getName())
+                : Bukkit.getWorld(position.getWorld().getUuid());
+            final Location location = new Location(bukkitWorld,
+                position.getX(), position.getY(), position.getZ(), position.getYaw(), position.getPitch());
+            PaperLib.teleportAsync(player, location);
+        });
     }
 
     @Override


### PR DESCRIPTION
On Folia, it can often be beneficial to schedule a teleportAsync task when the chunk is unloaded. In sporadic yet plausible cases, the user may be inevitably kicked, or in much, much rarer cases, the server may inevitably crash.